### PR TITLE
feat(hide-avatar): Hides the avatar from the team's overview.

### DIFF
--- a/src/main/webapp/app/custom/teams/teams-status/teams-status.component.html
+++ b/src/main/webapp/app/custom/teams/teams-status/teams-status.component.html
@@ -15,7 +15,7 @@
       >
       </jhi-team-image>
     </div>
-    <div class="avatar-image-wrapper d-flex align-self-center">
+    <div class="avatar-image-wrapper d-flex align-self-center" *ngIf="!team?.image">
       <div class="avatar-image" [ngClass]="hasLeveledUp ? 'avatar-image-level-up' : 'avatar-image-default'"></div>
     </div>
     <div class="status-meta d-flex justify-content-center mx-auto">


### PR DESCRIPTION
Normally there is the default avatar image visible, but if the team has an own image set, we should set this without default avatar as an overlay.

It often looks wired, like this one: 

<img width="477" alt="Bildschirmfoto 2022-08-23 um 16 17 13" src="https://user-images.githubusercontent.com/2960912/186184530-fbaebbb8-5a1e-46da-b5f6-5130c1025bd6.png">

